### PR TITLE
exact_name to allow fine control over name 

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -1,5 +1,13 @@
 variable "name" {
-  description = "Name of storage account, if it contains illegal characters (,-_ etc) those will be truncated."
+  description = "Name of storage account. Unless var.exact_name is true any illegal characters (,-_ etc) will be truncated and 6 random characters will be appended to this value."
+  default     = ""
+  type        = string
+}
+
+variable "exact_name" {
+  description = "When true, var.name is used exactly as passed"
+  type        = bool
+  default     = false
 }
 
 variable "resource_group_name" {

--- a/variables.tf
+++ b/variables.tf
@@ -1,6 +1,5 @@
 variable "name" {
   description = "Name of storage account. Unless var.exact_name is true any illegal characters (,-_ etc) will be truncated and 6 random characters will be appended to this value."
-  default     = ""
   type        = string
 }
 


### PR DESCRIPTION
Currently engineers have no actual control over the name when passing var.name as random characters are always appended to the passed variable. This is unfortunate because our naming scheme creates names with lengths ~20 char long, but with the additional characters breaks and throws errors 

```
Storage account names must be between 3 and 24 characters in length and only use numbers and lowercase letters
```

This PR adds an optional variable exact_name which, if true, passes var.name directly through without subjecting it to the current modification of `format("%s%ssa", lower(replace(var.name, "/[[:^alnum:]]/", "")), random_string.unique.result)`. 

The change is backwards compatible, existing instantiations of this module will be unchanged.

**OLD**
```
# input
name          = "acmecorpprodusscbackup"
# output 
name          = "acmecorpprodusscbackup123456" # breaks
```

**NEW**
```
# input
name           = "acmecorpprodusscbackup"
exact_name = true
# output 
name          = "acmecorpprodusscbackup" # ok
```