### PR TITLE
Ensure backwards compatibility for diagnostic_settings

### DIFF
--- a/examples/diagnostic/main.tf
+++ b/examples/diagnostic/main.tf
@@ -2,6 +2,7 @@ module "simple" {
   source = "../../"
 
   name                = "simple"
+  exact_name          = true
   resource_group_name = "simple-rg"
   location            = "westeurope"
 

--- a/main.tf
+++ b/main.tf
@@ -165,7 +165,7 @@ data "azurerm_monitor_diagnostic_categories" "default" {
 
 resource "azurerm_monitor_diagnostic_setting" "diag" {
   count                          = var.diagnostics != null ? 1 : 0
-  name                           = "${local.name}-sa-diag"
+  name                           = "${var.name}-sa-diag"
   target_resource_id             = "${azurerm_storage_account.storage.id}/blobServices/default"
   log_analytics_workspace_id     = local.parsed_diag.log_analytics_id
   eventhub_authorization_rule_id = local.parsed_diag.event_hub_auth_id


### PR DESCRIPTION
Pre version 3.0.1 setting var.name to 'foo' would create a diagnostic setting called 'foo-sa-diag', starting from v3.0.1 it would create a diagnostic setting with a name like 'foo03hbhsa-sa-diag' (unless var.exact_name is set) thereby making version 3.0.1 break backwards compability. This change ensures we're still backwards compatible.