### PR TITLE
Bump up azurerm version to v3.0.0

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 2.99.0"
+      version = "~> 3.0.0"
     }
     random = {
       source  = "hashicorp/random"


### PR DESCRIPTION
This fixes the following error with v2.99 Status=400 Code="MissingLastAccessTimeBasedTrackingPolicy" Message="Last access time based tracking policy must be enabled before using its specific actions in object lifecycle management policy"