### PR TITLE
Optionally use existing resource group

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -49,6 +49,7 @@ locals {
 }
 
 resource "azurerm_resource_group" "storage" {
+  count    = var.resource_group_create ? 1 : 0
   name     = var.resource_group_name
   location = var.location
 
@@ -63,8 +64,8 @@ resource "random_string" "unique" {
 
 resource "azurerm_storage_account" "storage" {
   name                      = local.name
-  resource_group_name       = azurerm_resource_group.storage.name
-  location                  = azurerm_resource_group.storage.location
+  resource_group_name       = var.resource_group_name
+  location                  = var.location
   account_kind              = var.account_kind
   account_tier              = var.account_tier
   account_replication_type  = var.account_replication_type

--- a/variables.tf
+++ b/variables.tf
@@ -13,6 +13,14 @@ variable "resource_group_name" {
   description = "Name of resource group to deploy resources in."
 }
 
+variable "resource_group_create" {
+  description = "Create resource group. Defaults to true"
+  default     = true
+  type        = bool
+}
+
+
+
 variable "location" {
   description = "Azure location where resources should be deployed."
 }


### PR DESCRIPTION
Optionally use existing resource group by setting "resource_group_create = false" 

Fixes #16 